### PR TITLE
-  added support for folder names in /data, so that each request either ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ All requests routed through caching proxy should have the initial
 
 -  `http://` ---> replaced with `http/`
 -  `https://` ---> replaced with `https/`
+-  optionally, prefix your URL with a cache folder ID made up of numbers, letters, hyphens and underscores
+    -  i.e. http://localhost:8092/my-folder-name/http/www.activevideo.com/
 
-```
+```javascript
    var cachingProxy = 'http://localhost:8092/';
    var urlToGet = 'http://developer.activevideo.com';
    
@@ -93,9 +95,22 @@ All requests routed through caching proxy should have the initial
    x.send();
 ```
 
-The response will be saved to the directory ./data/ by default, or if you started the proxy with.
+The response will be saved to the directory ./data/default/ by default, or "default" inside the dir you started the proxy with.
  
 The response content for any text file will be searched, and all absolute paths within the response text will be replaced with the path to the proxy. 
+
+Note: to use a different folder than "default", the URL should be updated to have a folder ID consisting
+of numbers, letters, hyphens and underscores:
+
+```
+'http://localhost:8092/load-test-1/http/www.activevideo.com/'
+//this will save files to:
+'./data/load-test-1/'
+
+````
+
+In this manner it is possible to cache multiple versions of the same resources by providing varying
+the caching folder id
 
 Source HTML before proxy does replacements
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -18,9 +18,7 @@ url = require('url'),
 mkdir = require('mkdirp').sync,
 
 exists = File.exists || Path.exists,
-existsSync = File.existsSync || Path.existsSync,
-
-directoryCheck = false;
+existsSync = File.existsSync || Path.existsSync;
 
 
 /**
@@ -39,6 +37,7 @@ function Cache(options, res) {
 Cache.prototype = {
     id: null,
     url: null,
+    directoryCheck: false,
     aborted: false,
     requestHeaders: null,
     requestBody: null,
@@ -171,7 +170,7 @@ Cache.prototype = {
 
         //this only creates it if it doesn't exist, global, only done once
         //since synchronous we don't want to do this all the time
-        if(!directoryCheck){
+        if(!this.directoryCheck){
             try{
                 mkdir(this._baseDir);
                 mkdir(this._tmpDir);
@@ -180,7 +179,7 @@ Cache.prototype = {
                 return;
             }
 
-            directoryCheck = true;
+            this.directoryCheck = true;
         }
 
 
@@ -216,6 +215,7 @@ Cache.prototype = {
                 console.log('(send304) Serving 304, ' + lastModified + '<=' + ifModified);
                 res.writeHead(304, {
                     'caching-proxy-served-from' : 'Cache',
+                    'caching-proxy-folder' : this.options.cacheDir,
                     'caching-proxy-source': this.getId()
                 });
 
@@ -431,6 +431,7 @@ Cache.prototype = {
 
         headers['caching-proxy-served-from'] = 'Fresh/Internet';
         headers['caching-proxy-source'] = this.getId();
+        headers['caching-proxy-folder'] = this.options.cacheDir;
 
 
         var contentType = headers && headers['content-type'];
@@ -691,6 +692,7 @@ Cache.prototype = {
 
         this.res.writeHead(code, {
             'caching-proxy-served-from' : 'Fresh',
+            'caching-proxy-folder' : this.options.cacheDir,
             'content-type': 'application/json',
             'caching-proxy-source': this.getId()
         });

--- a/lib/caching-proxy.js
+++ b/lib/caching-proxy.js
@@ -71,14 +71,21 @@ var CachingProxy = function(options) {
                 proxyPath = SERVER.ADDRESS.address + ':' + SERVER.ADDRESS.port;
             }
 
+            proxyPath = 'http://' + proxyPath + '/';
+
+            if(options.cacheDir){
+                proxyPath += options.cacheDir + '/';
+            }
+
             var cache = new Cache({
                 url: options.fullUrl,
                 headers: options.headers,
                 body: req.body,
-                dir: SERVER.DIR,
+                dir: SERVER.DIR + "/" + options.cacheDir,
                 method: options.method,
                 exclude: SERVER.EXCLUDE,
-                proxyPath: 'http://' + proxyPath + '/'
+                proxyPath: proxyPath,
+                cacheDir: options.cacheDir
             }, res);
 
 
@@ -117,13 +124,15 @@ var CachingProxy = function(options) {
 
         /**
          * Handles special cases,
-         *  1) Liveness check
-         *  2)
+         *  1) Liveness check /status
+         *  2) Ping check /ping
+         *  3) relative URLs
          * @param req
          * @param res
          * @returns {boolean}
          */
         handleSpecialCases: function (req, res) {
+            var parts = req.url.split('/');
             if (req.url.match(/^\/ping/)) {
                 console.warn('(handleSpecialCases) Serving 200, pong');
                 res.writeHead(200);
@@ -132,7 +141,7 @@ var CachingProxy = function(options) {
             } else if(req.url.match(/^\/status/)){
                 this.serveStatus(req, res);
                 return true;
-            } else if (req.url.indexOf('/http') !== 0) {
+            } else if (parts[1].indexOf('http') !== 0 && parts[2].indexOf('http') !== 0) {
                 console.warn('(handleSpecialCases) Serving 404, not absolute URL: ' + req.url);
                 res.writeHeader('404', {'content-type': 'text/plain'});
                 res.end('The URL provided to replay-server was not absolute, and relative paths cannot be resolved by it (' + req.url + ')\n');
@@ -166,8 +175,17 @@ var CachingProxy = function(options) {
                 requestParams = url.parse(requestUrl),
                 https = requestParams.href.indexOf('https') === 0,
                 options = {},
-                headers = util._extend({}, req.headers || {});
+                headers = util._extend({}, req.headers || {}),
+                requestCacheDir = "default"
             ;
+
+
+            if(req.url.indexOf('/http') !== 0){
+                var parts = req.url.split('/');
+                requestCacheDir = parts[1];
+            }
+
+            requestCacheDir = requestCacheDir.toLowerCase().replace(/[^a-z0-9\-\_]/ig, '');
 
 
             //console.log('https=' + https, ', original url=' + req.url + ' new url=' + requestUrl + ', params', requestParams);
@@ -187,6 +205,7 @@ var CachingProxy = function(options) {
             options.path = requestParams.path;
             options.headers = headers;
             options.fullUrl = requestUrl;
+            options.cacheDir = requestCacheDir;
 
             if (requestParams.auth) {
                 //options.auth = requestParams.auth;
@@ -211,7 +230,14 @@ var CachingProxy = function(options) {
          * @returns {string}
          */
         cleanRequestUrl: function (url) {
-            var cleanedUrl = url.replace(/^\/http\//, 'http://').replace(/^\/https\//, 'https://');
+            var parts = url.split('/');
+            if(parts[1] === 'http' || parts[1] === 'https'){
+                var cleanedUrl = url.replace(/^\/http\//, 'http://').replace(/^\/https\//, 'https://');
+            }else{
+                url = "/" + parts.slice(2).join('/');
+                var cleanedUrl = url.replace(/^\/http\//, 'http://').replace(/^\/https\//, 'https://');
+            }
+
 
             return cleanedUrl;
         },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caching-proxy",
   "description": "A caching proxy server useable in your front-end projects to cache API requests and rewrite their responses as needed to be routed through server - for tradeshows, demos, data that you know will be retired someday, and load testing in shared environments (exmample CloudTV where a server could be running thousands of browser sessions at once and you want to test server scalability independent of APIs an app might depend on, ala activevideo.com)",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "author": "Chad Wagner <cwagner@activevideo.com> (http://developer.activevideo.com/), Steve Oziel <S.Oziel@activevideo.com> ",
   "keywords": [
     "test",


### PR DESCRIPTION
...gets captured into "default" (the default folder) or the id of the request

-  new API supports both
   -  http://localhost:8092/http/madebychad.com/old/portfolio.php
   -  http://localhost:8092/folder-id/http/madebychad.com/old/portfolio.php
        (accepts folder-id consting of: a-z0-9\-\_)