### PR TITLE
-  long paths are now accounted in file naming by truncating them at 30 ...

### DIFF
--- a/install-as-daemon.sh
+++ b/install-as-daemon.sh
@@ -22,7 +22,7 @@ sudo n stable;
 npm install caching-proxy;
 
 echo '#!/bin/bash' > /var/www/html/caching-proxy/daemon.sh;
-echo '\n\n' >> /var/www/html/caching-proxy/daemon.sh;
+printf '\n\n' >> /var/www/html/caching-proxy/daemon.sh;
 echo 'cd /var/www/html/caching-proxy/node_modules/caching-proxy' >> /var/www/html/caching-proxy/daemon.sh;
 echo 'nohup ./daemon.sh -e token,rand -d /var/www/html/caching-proxy/data &' >> /var/www/html/caching-proxy/daemon.sh;
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -14,6 +14,7 @@ crypto = require('crypto'),
 http = require('follow-redirects').http,
 https = require('follow-redirects').https,
 url = require('url'),
+sanitize = require("sanitize-filename"),
 
 mkdir = require('mkdirp').sync,
 
@@ -117,7 +118,7 @@ Cache.prototype = {
 
         var urlInfo = url.parse(requestUrl);
         var fileParts = urlInfo.pathname.split('/').pop().split('.');
-        var fileName = fileParts[0];
+        var fileName = sanitize(fileParts[0].substr(0, 30)).replace(/[\,\.]/g,'-');
         var fileExt = fileParts[1] || 'txt';
 
         //only care about URL and post body

--- a/lib/caching-proxy.js
+++ b/lib/caching-proxy.js
@@ -141,7 +141,7 @@ var CachingProxy = function(options) {
             } else if(req.url.match(/^\/status/)){
                 this.serveStatus(req, res);
                 return true;
-            } else if (parts[1].indexOf('http') !== 0 && parts[2].indexOf('http') !== 0) {
+            } else if (parts[1].indexOf('http') !== 0 && (!parts[2] || parts[2].indexOf('http') !== 0)) {
                 console.warn('(handleSpecialCases) Serving 404, not absolute URL: ' + req.url);
                 res.writeHeader('404', {'content-type': 'text/plain'});
                 res.end('The URL provided to replay-server was not absolute, and relative paths cannot be resolved by it (' + req.url + ')\n');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caching-proxy",
   "description": "A caching proxy server useable in your front-end projects to cache API requests and rewrite their responses as needed to be routed through server - for tradeshows, demos, data that you know will be retired someday, and load testing in shared environments (exmample CloudTV where a server could be running thousands of browser sessions at once and you want to test server scalability independent of APIs an app might depend on, ala activevideo.com)",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Chad Wagner <cwagner@activevideo.com> (http://developer.activevideo.com/), Steve Oziel <S.Oziel@activevideo.com> ",
   "keywords": [
     "test",
@@ -24,7 +24,8 @@
     "optimist": ">=0.6.1",
     "follow-redirects" : ">=0.0.3",
     "mkdirp" : ">=0.5.0",
-    "request": ">=2.49.0"
+    "request": ">=2.49.0",
+    "sanitize-filename": ">=1.3.0"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
-  long paths are now accounted in file naming by truncating them at 30 characters
-  handle errors thrown when a provided URL is not absolute
-  fix newline characters in install script
-  bump version number 1 minor version