### PR TITLE
-  added support for caching of 404s, along with any other configurable ...

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -47,6 +47,8 @@ Cache.prototype = {
     secure : false,
     exclude: null,
 
+    allowedErrors: [],
+
     proxyPath : null,
     writeStream: null,
 
@@ -65,6 +67,10 @@ Cache.prototype = {
     init: function (options, res) {
         this.options = options || {};
         this.res = res;
+        this.allowedErrors = this.options.allowedErrors || [];
+        for(var i=0; i<this.allowedErrors.length; i++){
+            this.allowedErrors[i] = parseInt(this.allowedErrors[i], 10);
+        }
 
         // always initialize all instance properties
         this.dir = this.options.dir || undefined;
@@ -422,7 +428,7 @@ Cache.prototype = {
 
         this.responseStatus = incomingMessage.statusCode;
 
-        var success = incomingMessage.statusCode === 200;
+        var success = incomingMessage.statusCode === 200 || this.allowedErrors.indexOf(incomingMessage.statusCode) !== -1;
         var headers = incomingMessage.headers;
 
         this.responseHeaders = {
@@ -493,7 +499,7 @@ Cache.prototype = {
      */
     onEnd: function(res, incomingMessage){
 
-        var success = incomingMessage.statusCode === 200;
+        var success = incomingMessage.statusCode === 200 || this.allowedErrors.indexOf(incomingMessage.statusCode) !== -1;
 
         //We only write headers/data upon 100% success in the case of a file that
         //is not being piped
@@ -527,7 +533,7 @@ Cache.prototype = {
     onEndSecure: function(clientRequest, res, incomingMessage){
         this.writeBodySync(this.responseBody);
 
-        var success = incomingMessage.statusCode === 200;
+        var success = incomingMessage.statusCode === 200 || this.allowedErrors.indexOf(incomingMessage.statusCode) !== -1;
         if(success){
             this.moveTempFiles(incomingMessage);
         }
@@ -611,7 +617,7 @@ Cache.prototype = {
     },
 
     moveTempFiles: function(incomingMessage){
-        var success = incomingMessage.statusCode === 200 && !this.aborted;
+        var success = (incomingMessage.statusCode === 200 || this.allowedErrors.indexOf(incomingMessage.statusCode) !== -1) && !this.aborted;
 
         if(!success) return;
 

--- a/lib/caching-proxy.js
+++ b/lib/caching-proxy.js
@@ -4,6 +4,7 @@
  * -p <port number> the port to run on, the default is 8092
  * -e <CSV exclusions> a comma separated list of URL parameters to exclude from the hash, for example rand,cache-buster, etc (will still be included in proxied request, just not used when determining if this request matches a previous one)
  * -s Expose the status API via /status, default is not to if this flag is omitted. If -s is present, then /status will show all pending request as JSON
+ * -b Comma separated list of allowed error headers, default is to cache 404 errors
  */
 
 
@@ -13,6 +14,7 @@ var args = require('optimist').argv,
     path = require('path'),
     exclude = (args.e && args.e.trim && args.e.trim()) || '',
     dir = (args.d && args.d.trim && args.d.trim()) || __dirname + '/../data',
+    allowedErrors = !args.b ? '404' : (args.b && args.b.toString && args.b.toString().trim()),
 
     http = require('http'),
     url = require('url'),
@@ -38,6 +40,7 @@ var CachingProxy = function(options) {
         ADDRESS: {},
         DIR: path.resolve(options.dir || dir),
         EXCLUDE: (options.exclude || exclude).split(','),
+        ALLOWED_ERRORS: allowedErrors,
 
         handler: function (req, res) {
             //is this a health check?
@@ -85,7 +88,8 @@ var CachingProxy = function(options) {
                 method: options.method,
                 exclude: SERVER.EXCLUDE,
                 proxyPath: proxyPath,
-                cacheDir: options.cacheDir
+                cacheDir: options.cacheDir,
+                allowedErrors: (allowedErrors || '').split(',')
             }, res);
 
 
@@ -263,6 +267,7 @@ var CachingProxy = function(options) {
             'Starting a CacingProxy server\n\tPORT='
             + SERVER.PORT + ', \n\tBASE DATA DIR: '
             + SERVER.DIR +'\n\tEXCLUSIONS: ' + (SERVER.EXCLUDE.join(',') || '(Not Applicable, No Exclusions)')
+            + '\n\tAllowed Errors: ' + SERVER.ALLOWED_ERRORS
             + '\n\tStatus Service via /status: ' + (exposeRequestStatus ? 'ON' : 'OFF') + ''
     );
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caching-proxy",
   "description": "A caching proxy server useable in your front-end projects to cache API requests and rewrite their responses as needed to be routed through server - for tradeshows, demos, data that you know will be retired someday, and load testing in shared environments (exmample CloudTV where a server could be running thousands of browser sessions at once and you want to test server scalability independent of APIs an app might depend on, ala activevideo.com)",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Chad Wagner <cwagner@activevideo.com> (http://developer.activevideo.com/), Steve Oziel <S.Oziel@activevideo.com> ",
   "keywords": [
     "test",


### PR DESCRIPTION
...error codes

-  this is added so that APIs that use 404 on purpose, such as "no image available for this asset" will be cached as a valid response