### PR TITLE
Correct content-type response headers received from image server

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -444,8 +444,9 @@ Cache.prototype = {
         // The type of image file being requested is detected by the presence of the file extension in the URL.
         var imageTypeMatches = clientRequest.url.match(/\.(png|jpeg|jpg|gif)/i);
         var imageType = imageTypeMatches && imageTypeMatches[1];
+        imageType = (imageType === 'jpg') ? 'jpeg' : imageType;
         if (imageType && headers && headers['content-type']) {
-            headers['content-type'] = "image/" + imageType;
+            headers['content-type'] = 'image/' + imageType;
         }
 
         var contentType = headers && headers['content-type'];

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -440,6 +440,13 @@ Cache.prototype = {
         headers['caching-proxy-source'] = this.getId();
         headers['caching-proxy-folder'] = this.options.cacheDir;
 
+        // Force the content-type header to match the type of image file being requested.
+        // The type of image file being requested is detected by the presence of the file extension in the URL.
+        var imageTypeMatches = clientRequest.url.match(/\.(png|jpeg|gif)/i);
+        var imageType = imageTypeMatches && imageTypeMatches[1];
+        if (imageType && headers && headers['content-type']) {
+            headers['content-type'] = headers['content-type'].replace("text/html", "image/" + imageType);
+        }
 
         var contentType = headers && headers['content-type'];
         var contentLength = headers && headers['content-length'];

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -442,10 +442,10 @@ Cache.prototype = {
 
         // Force the content-type header to match the type of image file being requested.
         // The type of image file being requested is detected by the presence of the file extension in the URL.
-        var imageTypeMatches = clientRequest.url.match(/\.(png|jpeg|gif)/i);
+        var imageTypeMatches = clientRequest.url.match(/\.(png|jpeg|jpg|gif)/i);
         var imageType = imageTypeMatches && imageTypeMatches[1];
         if (imageType && headers && headers['content-type']) {
-            headers['content-type'] = headers['content-type'].replace("text/html", "image/" + imageType);
+            headers['content-type'] = "image/" + imageType;
         }
 
         var contentType = headers && headers['content-type'];


### PR DESCRIPTION
If the "content-type" response header for an image request is incorrectly set to "text/html", correct it by changing it to "image/<type>". e.g. "image/png"

This is a workaround for strange behavior seen by the charter image servers, especially with channel logos.
