### PR TITLE
console.log override binding fix

### DIFF
--- a/lib/caching-proxy.js
+++ b/lib/caching-proxy.js
@@ -28,13 +28,14 @@ var args = require('optimist').argv,
 
     // Console log override with timestamp
     if (console && console.log) {
-        var old = console.log;
-        var timestamp = dateFormat("yyyy-mm-dd HH:MM:ss:l");
-        console.log = function() {
+        originalconsolelog = console.log.bind(console);
+        console.log = function () {
+            var timestamp = dateFormat("yyyy-mm-dd HH:MM:ss:l");
             Array.prototype.unshift.call(arguments, '[' + timestamp + '] ');
-            old.apply(this, arguments);
+            originalconsolelog.apply(this, arguments);
         }
     }
+
 
 /**
  * CachingProxy is a class for greedily caching proxied content for


### PR DESCRIPTION
Fixed a console.log override issue where the timestamp would always be the same due to a lack of binding.