### PR TITLE
fix issue with getId stripping parameter values before generating hash

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -127,8 +127,10 @@ Cache.prototype = {
         var requestUrl = this.method + ' ' + this.removeAuthFromString(this.url);
 
         for(var i=0; i<this.exclude.length; i++){
-            var regex = new RegExp(this.exclude[i]+'\=[a-zA-Z0-9\\-\\_]+[\&]*','ig')
-            requestUrl = requestUrl.replace(regex, '');
+            if (this.exclude[i].length > 0) {
+              var regex = new RegExp(this.exclude[i]+'\=[a-zA-Z0-9\\-\\_]+[\&]*','ig')
+              requestUrl = requestUrl.replace(regex, '');
+            }
         }
         //remove any parameters without values, like ?123
         requestUrl = requestUrl.replace(/[\&\?][0-9]+[\&]*$/i, '');


### PR DESCRIPTION
First off, thanks for this excellent project, it has been extremely helpful!

I found a bug while using the project and wrote up a small patch. The issue is explained here: https://github.com/joshea0/caching-proxy/issues/1

If you'd prefer I open an issue on this repo or if you need anything else changed/added to get this merged, please let me know and I'll be happy to make it happen.