### PR TITLE
fixing onEndSecure missing path parameter

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -612,7 +612,8 @@ Cache.prototype = {
      */
     onEndSecure: function(clientRequest, res, incomingMessage){
         console.log("cache.onEndSecure()");
-        this.writeBodySync(this.responseBody);
+        const path = this.getFilePathBody(true);
+        this.writeBodySync(path, this.responseBody);
 
         var success = incomingMessage.statusCode === 200 || this.allowedErrors.indexOf(incomingMessage.statusCode) !== -1;
         if(success){


### PR DESCRIPTION
there was small bug with missing parameter. writeBodySync expects path to be first parameter. so i have added it. 