### PR TITLE
bug/at-symbol-in-filename

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -139,7 +139,7 @@ Cache.prototype = {
 
         var urlInfo = url.parse(requestUrl);
         var fileParts = urlInfo.pathname.split('/').pop().split('.');
-        var fileName = sanitize(fileParts[0].substr(0, 30)).replace(/[\,\.]/g,'-');
+        var fileName = sanitize(fileParts[0].substr(0, 30)).replace(/[\,\.\@]/g,'-');
         var fileExt = fileParts[1] || 'txt';
 
         //only care about URL and post body

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caching-proxy",
   "description": "A caching proxy server useable in your front-end projects to cache API requests and rewrite their responses as needed to be routed through server - for tradeshows, demos, data that you know will be retired someday, and load testing in shared environments (exmample CloudTV where a server could be running thousands of browser sessions at once and you want to test server scalability independent of APIs an app might depend on, ala activevideo.com)",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "author": "Chad Wagner <cwagner@activevideo.com> (http://developer.activevideo.com/), Steve Oziel <S.Oziel@activevideo.com> ",
   "keywords": [
     "test",


### PR DESCRIPTION
- remove '@' from file names when sanitizing filename, for example, 'api.mapbox.com/someMap.png@2x'
- bump version