### PR TITLE
bug/https-amazon

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -519,11 +519,7 @@ Cache.prototype = {
             incomingMessage.on('data', this.appendData.bind(this));
             incomingMessage.resume();
             return;
-        }else if(this.secure){
-            this.responseBody = [];
-            incomingMessage.on('end', this.onEndSecure.bind(this, clientRequest, res, incomingMessage));
-            incomingMessage.on('data', this.appendData.bind(this));
-        }else{
+        } else{
             this.sendHeaders(res, incomingMessage.statusCode, headers);
             incomingMessage.pipe(res);
 
@@ -604,25 +600,6 @@ Cache.prototype = {
         //the text file, we need to stream the response rather than send it
         //all at once, as it may be large
         this.sendCachedResponse(res, incomingMessage.statusCode, headers);
-    },
-
-    /**
-     * The secure serving has race conditions present and is not stable/supported at this time
-     * @param clientRequest The incoming client request we are servicing
-     * @param res
-     * @param incomingMessage
-     */
-    onEndSecure: function(clientRequest, res, incomingMessage){
-        console.log("cache.onEndSecure()");
-        const path = this.getFilePathBody(true);
-        this.writeBodySync(path, this.responseBody);
-
-        var success = incomingMessage.statusCode === 200 || this.allowedErrors.indexOf(incomingMessage.statusCode) !== -1;
-        if(success){
-            this.moveTempFiles(incomingMessage);
-        }
-
-        this.serve(clientRequest, res);
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caching-proxy",
   "description": "A caching proxy server useable in your front-end projects to cache API requests and rewrite their responses as needed to be routed through server - for tradeshows, demos, data that you know will be retired someday, and load testing in shared environments (exmample CloudTV where a server could be running thousands of browser sessions at once and you want to test server scalability independent of APIs an app might depend on, ala activevideo.com)",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "author": "Chad Wagner <cwagner@activevideo.com> (http://developer.activevideo.com/), Steve Oziel <S.Oziel@activevideo.com> ",
   "keywords": [
     "test",
@@ -19,7 +19,8 @@
     "lib": "./lib"
   },
   "scripts": {
-    "start": "node start.js -p 8092 -d data -e token,rand"
+    "start": "node start.js -p 8092 -d data -e token,rand",
+    "startdev": "node $NODE_DEBUG_OPTION start.js -p 8092 -d data -e token,rand"
   },
   "dependencies": {
     "dateformat": "^2.0.0",


### PR DESCRIPTION
- https requests that were binary were being corrupted
  - fix: send https responses the same path as http responses, without treating them differently
  - https requests are now piped directly to the file on disk without any intermediary buffering